### PR TITLE
Style: Change Current Home Runs bar to orange

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,8 +186,8 @@ datasets: [
 {
 label: 'Current Home Runs',
 data: currentHomeRuns,
-backgroundColor: 'rgba(76, 175, 80, 0.8)', // Green for current
-borderColor: 'rgba(76, 175, 80, 1)',
+backgroundColor: 'rgba(255, 159, 64, 0.8)', // Orange for current
+borderColor: 'rgba(255, 159, 64, 1)',
 borderWidth: 1,
 borderRadius: 8,
 },


### PR DESCRIPTION
I've updated the Chart.js configuration in your `index.html` file to change the bar color for the 'Current Home Runs' dataset.

- I modified `backgroundColor` from green (rgba(76, 175, 80, 0.8)) to orange (rgba(255, 159, 64, 0.8)).
- I modified `borderColor` from green (rgba(76, 175, 80, 1)) to orange (rgba(255, 159, 64, 1)).

This should address your request to change the specified bar color.