### PR TITLE
Update Sports tab to link to mlb_detroit.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,9 +50,7 @@ Information
 <button id="tab-resources" class="tab-inactive py-4 px-6 text-sm font-medium border-b-2 focus:outline-none">
 Resources
 </button>
-<button id="tab-sports" class="tab-inactive py-4 px-6 text-sm font-medium border-b-2 focus:outline-none">
-Sports
-</button>
+<a id="tab-sports" href="mlb_detroit.html" class="tab-inactive py-4 px-6 text-sm font-medium border-b-2 focus:outline-none text-gray-500 hover:text-gray-800 hover:border-gray-300">Sports</a>
 <button id="tab-contact" class="tab-inactive py-4 px-6 text-sm font-medium border-b-2 focus:outline-none">
 Contact
 </button>


### PR DESCRIPTION
I changed the 'Sports' navigation tab in index.html from a button to an anchor tag. It now directly links to mlb_detroit.html. Styling was adjusted to maintain visual consistency with other tabs. The JavaScript for tab content switching is unaffected for the remaining tabs.